### PR TITLE
Replace --align-equals with --align-clauses option

### DIFF
--- a/bin/src/Bin/FormatOptions.purs
+++ b/bin/src/Bin/FormatOptions.purs
@@ -15,7 +15,7 @@ import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Newtype (class Newtype)
 import Data.Traversable (traverse)
 import Data.YAML.Foreign.Encode (class ToYAML, entry, object)
-import Pursfmt (ImportSortOption(..), ImportWrapOption(..), ThenPlacementOption(..), TypeArrowOption(..), UnicodeOption(..))
+import Pursfmt (AlignClausesOption(..), ImportSortOption(..), ImportWrapOption(..), ThenPlacementOption(..), TypeArrowOption(..), UnicodeOption(..))
 
 type FormatOptions =
   { importSort :: ImportSortOption
@@ -31,7 +31,7 @@ type FormatOptions =
   , compactRecords :: Boolean
   , letClauseSameLine :: Boolean
   , singleLineLetIn :: Boolean
-  , alignEquals :: Boolean
+  , alignClauses :: AlignClausesOption
   }
 
 -- Newtype wrapper for ToYAML instance
@@ -54,7 +54,7 @@ defaults =
   , compactRecords: false
   , letClauseSameLine: false
   , singleLineLetIn: false
-  , alignEquals: false
+  , alignClauses: AlignClausesNone
   }
 
 formatOptions :: ArgParser FormatOptions
@@ -140,10 +140,19 @@ formatOptions =
         Arg.flag [ "--single-line-let-in", "-slli" ]
           "Keep single-binding let expressions on one line when they fit."
           # Arg.boolean
-    , alignEquals:
-        Arg.flag [ "--align-equals", "-ae" ]
-          "Align equals signs across clauses of the same function definition."
-          # Arg.boolean
+    , alignClauses:
+        Arg.choose "align clauses"
+          [ Arg.flag [ "--align-clauses-none", "-acn" ]
+              "No alignment of clauses.\nDefault."
+              $> AlignClausesNone
+          , Arg.flag [ "--align-clauses-equals", "-ace" ]
+              "Align equals signs across clauses of the same function definition."
+              $> AlignClausesEquals
+          , Arg.flag [ "--align-clauses-full", "-acf" ]
+              "Align binder columns and equals signs across clauses of the same function definition."
+              $> AlignClausesFull
+          ]
+          # Arg.default defaults.alignClauses
     }
 
 unicodeOption :: ArgParser UnicodeOption
@@ -177,7 +186,7 @@ fromJson json = do
   compactRecords <- obj .:? "compactRecords"
   letClauseSameLine <- obj .:? "letClauseSameLine"
   singleLineLetIn <- obj .:? "singleLineLetIn"
-  alignEquals <- obj .:? "alignEquals"
+  alignClauses <- traverse alignClausesFromString =<< obj .:? "alignClauses"
   pure
     { importSort: fromMaybe defaults.importSort importSort
     , importWrap: fromMaybe defaults.importWrap importWrap
@@ -192,7 +201,7 @@ fromJson json = do
     , compactRecords: fromMaybe defaults.compactRecords compactRecords
     , letClauseSameLine: fromMaybe defaults.letClauseSameLine letClauseSameLine
     , singleLineLetIn: fromMaybe defaults.singleLineLetIn singleLineLetIn
-    , alignEquals: fromMaybe defaults.alignEquals alignEquals
+    , alignClauses: fromMaybe defaults.alignClauses alignClauses
     }
 
 toJson :: FormatOptions -> Json
@@ -211,7 +220,7 @@ toJson options =
     # extend (assoc "compactRecords" options.compactRecords)
     # extend (assoc "letClauseSameLine" options.letClauseSameLine)
     # extend (assoc "singleLineLetIn" options.singleLineLetIn)
-    # extend (assoc "alignEquals" options.alignEquals)
+    # extend (assoc "alignClauses" (alignClausesToString options.alignClauses))
 
 thenPlacementFromString :: String -> Either JsonDecodeError ThenPlacementOption
 thenPlacementFromString = case _ of
@@ -272,6 +281,19 @@ importSortToString :: ImportSortOption -> String
 importSortToString = case _ of
   ImportSortSource -> "source"
   ImportSortIde -> "ide"
+
+alignClausesFromString :: String -> Either JsonDecodeError AlignClausesOption
+alignClausesFromString = case _ of
+  "none" -> pure AlignClausesNone
+  "equals" -> pure AlignClausesEquals
+  "full" -> pure AlignClausesFull
+  other -> throwError $ UnexpectedValue (Json.fromString other)
+
+alignClausesToString :: AlignClausesOption -> String
+alignClausesToString = case _ of
+  AlignClausesNone -> "none"
+  AlignClausesEquals -> "equals"
+  AlignClausesFull -> "full"
 
 instance toYAMLFormatOptions :: ToYAML FormatOptionsYAML where
   toYAML (FormatOptionsYAML options) =

--- a/bin/src/Bin/Worker.purs
+++ b/bin/src/Bin/Worker.purs
@@ -45,7 +45,7 @@ type WorkerConfig =
   , compactRecords :: Boolean
   , letClauseSameLine :: Boolean
   , singleLineLetIn :: Boolean
-  , alignEquals :: Boolean
+  , alignClauses :: String
   }
 
 toWorkerConfig :: FormatOptions -> WorkerConfig
@@ -63,7 +63,7 @@ toWorkerConfig options =
   , compactRecords: options.compactRecords
   , letClauseSameLine: options.letClauseSameLine
   , singleLineLetIn: options.singleLineLetIn
-  , alignEquals: options.alignEquals
+  , alignClauses: FormatOptions.alignClausesToString options.alignClauses
   }
 
 type WorkerData =
@@ -107,7 +107,7 @@ formatCommand args operators contents = do
           , compactRecords = args.compactRecords
           , letClauseSameLine = args.letClauseSameLine
           , singleLineLetIn = args.singleLineLetIn
-          , alignEquals = args.alignEquals
+          , alignClauses = args.alignClauses
           }
       Right $ print $ toDoc $ formatModule opts ok
     ParseSucceededWithErrors _ errs -> do
@@ -147,7 +147,9 @@ formatInPlaceCommand shouldCheck operators { filePath, config } = do
       , compactRecords: config.compactRecords
       , letClauseSameLine: config.letClauseSameLine
       , singleLineLetIn: config.singleLineLetIn
-      , alignEquals: config.alignEquals
+      , alignClauses:
+          fromRight' (\_ -> unsafeCrashWith "Unknown alignClauses value") do
+            FormatOptions.alignClausesFromString config.alignClauses
       }
   contents <- FS.readTextFile UTF8 filePath
   start <- liftEffect hrtime

--- a/src/Pursfmt.purs
+++ b/src/Pursfmt.purs
@@ -5,6 +5,7 @@ module Pursfmt
   , ThenPlacementOption(..)
   , ImportSortOption(..)
   , ImportWrapOption(..)
+  , AlignClausesOption(..)
   , Format
   , formatModule
   , formatDecl
@@ -27,7 +28,7 @@ import Data.Foldable (foldMap, foldl, foldr, all)
 import Data.List.NonEmpty as NonEmptyList
 import Data.Traversable (traverse)
 import Data.Map as Map
-import Data.Maybe (Maybe(..), isJust, maybe)
+import Data.Maybe (Maybe(..), fromMaybe, isJust, maybe)
 import Data.Monoid (power)
 import Data.String.Pattern (Pattern(..)) as String
 import Data.Monoid as Monoid
@@ -73,6 +74,13 @@ data ImportSortOption
 
 derive instance eqImportSortOpion :: Eq ImportSortOption
 
+data AlignClausesOption
+  = AlignClausesNone
+  | AlignClausesEquals
+  | AlignClausesFull
+
+derive instance eqAlignClausesOption :: Eq AlignClausesOption
+
 type FormatOptions e a =
   { formatError :: e -> FormatDoc a
   , unicode :: UnicodeOption
@@ -85,7 +93,7 @@ type FormatOptions e a =
   , compactRecords :: Boolean
   , letClauseSameLine :: Boolean
   , singleLineLetIn :: Boolean
-  , alignEquals :: Boolean
+  , alignClauses :: AlignClausesOption
   }
 
 defaultFormatOptions :: forall e a. FormatError e => FormatOptions e a
@@ -101,7 +109,7 @@ defaultFormatOptions =
   , compactRecords: false
   , letClauseSameLine: false
   , singleLineLetIn: false
-  , alignEquals: false
+  , alignClauses: AlignClausesNone
   }
 
 class FormatError e where
@@ -1540,31 +1548,80 @@ formatLetGroups conf = formatDeclGroups letDeclGroupSeparator letGroup formatLet
     LetBindingPattern _ _ _ -> DeclGroupUnknown
     LetBindingError _ -> DeclGroupUnknown
 
--- | Measure the single-line width of a value binding's LHS (name + binders).
--- | Only measures the last line to exclude leading comments.
-valueLhsWidth :: forall e a. FormatOptions e a -> ValueBindingFields e -> Int
-valueLhsWidth conf { name, binders } =
+-- | Render a FormatDoc to a single-line string for width measurement.
+-- | Takes only the last line to exclude leading comments.
+measureLastLineWidth :: forall a. FormatDoc a -> Int
+measureLastLineWidth doc =
   let
-    lhsDoc = Doc.toDoc $ case Array.length binders of
-      0 -> formatName conf name
-      _ -> formatName conf name `space` joinWithMap space (flexGroup <<< formatBinder conf) binders
-    rendered = Dodo.print Dodo.plainText { pageWidth: 99999, ribbonRatio: 1.0, indentWidth: 2, indentUnit: "  " } lhsDoc
+    rendered = Dodo.print Dodo.plainText { pageWidth: top, ribbonRatio: 1.0, indentWidth: 2, indentUnit: "  " } (Doc.toDoc doc)
   in
     case SCU.lastIndexOf (String.Pattern "\n") rendered of
       Just i -> SCU.length rendered - i - 1
       Nothing -> SCU.length rendered
 
+-- | Measure the single-line width of a single formatted binder.
+binderWidth :: forall e a. FormatOptions e a -> Binder e -> Int
+binderWidth conf = measureLastLineWidth <<< flexGroup <<< formatBinder conf
+
+-- | Measure the single-line width of a value binding's LHS (name + binders).
+valueLhsWidth :: forall e a. FormatOptions e a -> ValueBindingFields e -> Int
+valueLhsWidth conf { name, binders } =
+  measureLastLineWidth $ case Array.length binders of
+    0 -> formatName conf name
+    _ -> formatName conf name `space` joinWithMap space (flexGroup <<< formatBinder conf) binders
+
+-- | Compute the max width for each binder column across multiple clauses.
+binderColumnWidths :: forall e a. FormatOptions e a -> Array (ValueBindingFields e) -> Array Int
+binderColumnWidths conf bindings =
+  let
+    allWidths = map (\{ binders } -> map (binderWidth conf) binders) bindings
+    maxCols = foldl (\acc ws -> max acc (Array.length ws)) 0 allWidths
+  in
+    Array.mapWithIndex (\i _ -> foldl (\acc ws -> max acc (fromMaybe 0 (Array.index ws i))) 0 allWidths) (Array.replicate maxCols 0)
+
+-- | Compute the LHS width when binders are column-aligned.
+-- | Non-last binders use column max widths; last binder uses its actual width
+-- | since it isn't padded (equals-alignment handles the gap).
+columnAlignedLhsWidth :: forall e a. FormatOptions e a -> Array Int -> ValueBindingFields e -> Int
+columnAlignedLhsWidth conf colWidths { name, binders } =
+  measureLastLineWidth (formatName conf name) + 1 + foldl (+) 0 paddedWidths
+  where
+  numBinders = Array.length binders
+  paddedWidths = Array.mapWithIndex
+    ( \i binder ->
+        if i == numBinders - 1 then binderWidth conf binder
+        else fromMaybe 0 (Array.index colWidths i) + 1
+    )
+    binders
+
+-- | Compute alignment parameters for a set of value bindings.
+computeAlignment :: forall e a. FormatOptions e a -> AlignClausesOption -> Array (ValueBindingFields e) -> { mbColumnWidths :: Maybe (Array Int), maxWidth :: Int }
+computeAlignment conf alignMode bindings =
+  let
+    mbColumnWidths = if alignMode == AlignClausesFull then Just (binderColumnWidths conf bindings) else Nothing
+    maxWidth = case mbColumnWidths of
+      Just colWidths -> foldl (\acc vb -> max acc (columnAlignedLhsWidth conf colWidths vb)) 0 bindings
+      Nothing -> foldl (\acc vb -> max acc (valueLhsWidth conf vb)) 0 bindings
+  in
+    { mbColumnWidths, maxWidth }
+
 -- | Format a value binding with padding before the `=` to align with other clauses.
-formatValueBindingAligned :: forall e a. Int -> Format (ValueBindingFields e) e a
-formatValueBindingAligned maxWidth conf binding@{ name, binders, guarded } =
+-- | When columnWidths is provided, also aligns each binder column.
+formatValueBindingAligned :: forall e a. Maybe (Array Int) -> Int -> Format (ValueBindingFields e) e a
+formatValueBindingAligned mbColumnWidths maxWidth conf binding@{ name, binders, guarded } =
   case guarded of
     Unconditional tok (Where { expr, bindings }) ->
       let
-        currentWidth = valueLhsWidth conf binding
+        currentWidth = case mbColumnWidths of
+          Just colWidths -> columnAlignedLhsWidth conf colWidths binding
+          Nothing -> valueLhsWidth conf binding
         padding = max 0 (maxWidth - currentWidth)
-        lhs = formatName conf name
-          `flexSpaceBreak`
-            indent (joinWithMap spaceBreak (anchor <<< formatBinder conf) binders)
+        lhs = case mbColumnWidths of
+          Just colWidths -> formatName conf name `space` formatBindersColumnAligned conf colWidths binders
+          Nothing ->
+            formatName conf name
+              `flexSpaceBreak`
+                indent (joinWithMap spaceBreak (anchor <<< formatBinder conf) binders)
         rhs = Hang.toFormatDoc (indent (anchor (formatToken conf tok)) `hang` formatHangingExpr conf expr)
       in
         Doc.fromDoc
@@ -1576,18 +1633,34 @@ formatValueBindingAligned maxWidth conf binding@{ name, binders, guarded } =
             indent (foldMap (formatWhere conf) bindings)
     Guarded _ -> formatValueBinding conf binding
 
--- | Try to align `=` across top-level declaration clauses of the same function.
+-- | Format binders with column alignment: each positional binder is padded to its column width.
+formatBindersColumnAligned :: forall e a. FormatOptions e a -> Array Int -> Array (Binder e) -> FormatDoc a
+formatBindersColumnAligned conf colWidths binders =
+  joinWithMap space identity $ Array.mapWithIndex padBinder binders
+  where
+  numBinders = Array.length binders
+  padBinder i binder =
+    let
+      formatted = flexGroup (formatBinder conf binder)
+      targetWidth = fromMaybe 0 (Array.index colWidths i)
+      currentWidth = binderWidth conf binder
+      padding = max 0 (targetWidth - currentWidth)
+    in
+      if i == numBinders - 1 then formatted
+      else Doc.fromDoc (Doc.toDoc formatted <> Dodo.text (power " " padding))
+
+-- | Try to align clauses of the same top-level function.
 alignTopLevelDecls :: forall e a. FormatOptions e a -> NonEmptyList.NonEmptyList (Declaration e) -> Maybe (FormatDoc a)
 alignTopLevelDecls conf decls = do
-  guard conf.alignEquals
+  guard (conf.alignClauses /= AlignClausesNone)
   let declArray = Array.fromFoldable decls
   let bindings = Array.mapMaybe extractDeclValue declArray
   guard (Array.length bindings >= 2)
   guard (all isUnconditional bindings)
-  let maxWidth = foldl (\acc vb -> max acc (valueLhsWidth conf vb)) 0 bindings
+  let { mbColumnWidths, maxWidth } = computeAlignment conf conf.alignClauses bindings
   pure $ joinWithMap break
     ( \d -> case d of
-        DeclValue vb | isUnconditional vb -> formatValueBindingAligned maxWidth conf vb
+        DeclValue vb | isUnconditional vb -> formatValueBindingAligned mbColumnWidths maxWidth conf vb
         _ -> formatDecl conf d
     )
     declArray
@@ -1596,17 +1669,17 @@ alignTopLevelDecls conf decls = do
     DeclValue vb -> Just vb
     _ -> Nothing
 
--- | Try to align `=` across let binding clauses of the same function.
+-- | Try to align clauses of the same let-bound function.
 alignLetBindings :: forall e a. FormatOptions e a -> NonEmptyList.NonEmptyList (LetBinding e) -> Maybe (FormatDoc a)
 alignLetBindings conf decls = do
-  guard conf.alignEquals
+  guard (conf.alignClauses /= AlignClausesNone)
   let declArray = Array.fromFoldable decls
   bindings <- traverse extractLetBinding declArray
   guard (Array.length bindings >= 2)
   guard (allSameName bindings)
   guard (all isUnconditional bindings)
-  let maxWidth = foldl (\acc vb -> max acc (valueLhsWidth conf vb)) 0 bindings
-  pure $ joinWithMap break (formatValueBindingAligned maxWidth conf) bindings
+  let { mbColumnWidths, maxWidth } = computeAlignment conf conf.alignClauses bindings
+  pure $ joinWithMap break (formatValueBindingAligned mbColumnWidths maxWidth conf) bindings
   where
   extractLetBinding = case _ of
     LetBindingName vb -> Just vb

--- a/test/FormatDirective.purs
+++ b/test/FormatDirective.purs
@@ -120,7 +120,7 @@ parseDirectivesFromModule (Module { header: ModuleHeader header, body }) =
         , compactRecords: opts.compactRecords
         , letClauseSameLine: opts.letClauseSameLine
         , singleLineLetIn: opts.singleLineLetIn
-        , alignEquals: opts.alignEquals
+        , alignClauses: opts.alignClauses
         }
     }
     where

--- a/test/snapshots/AlignEquals.input
+++ b/test/snapshots/AlignEquals.input
@@ -1,5 +1,6 @@
--- @format --align-equals
--- @format --align-equals --let-clause-same-line
+-- @format --align-clauses-equals
+-- @format --align-clauses-full
+-- @format --align-clauses-full --let-clause-same-line
 module AlignEquals where
 
 -- Multiple clauses with different pattern widths

--- a/test/snapshots/AlignEquals.output
+++ b/test/snapshots/AlignEquals.output
@@ -28,7 +28,7 @@ example f comp xs =
   in
     sortOnBy f h xs
 
--- @format --align-equals
+-- @format --align-clauses-equals
 module AlignEquals where
 
 -- Multiple clauses with different pattern widths
@@ -59,13 +59,13 @@ example f comp xs =
   in
     sortOnBy f h xs
 
--- @format --align-equals --let-clause-same-line
+-- @format --align-clauses-full
 module AlignEquals where
 
 -- Multiple clauses with different pattern widths
-g Nothing Nothing   = EQ
+g Nothing  Nothing  = EQ
 g (Just _) Nothing  = GT
-g Nothing (Just _)  = LT
+g Nothing  (Just _) = LT
 g (Just a) (Just b) = comp a b
 
 -- With a type signature
@@ -74,7 +74,7 @@ foo 0 = 1
 foo n = n + 1
 
 -- Different pattern lengths
-bar true x  = x * 2
+bar true  x = x * 2
 bar false x = x + 1
 
 -- Single clause (no alignment needed)
@@ -82,8 +82,39 @@ baz x = x + 1
 
 -- Let binding with multiple clauses
 example f comp xs =
-  let h Nothing Nothing   = EQ
+  let
+    h Nothing  Nothing  = EQ
+    h (Just _) Nothing  = GT
+    h Nothing  (Just _) = LT
+    h (Just a) (Just b) = comp a b
+  in
+    sortOnBy f h xs
+
+-- @format --align-clauses-full --let-clause-same-line
+module AlignEquals where
+
+-- Multiple clauses with different pattern widths
+g Nothing  Nothing  = EQ
+g (Just _) Nothing  = GT
+g Nothing  (Just _) = LT
+g (Just a) (Just b) = comp a b
+
+-- With a type signature
+foo :: Int -> Int
+foo 0 = 1
+foo n = n + 1
+
+-- Different pattern lengths
+bar true  x = x * 2
+bar false x = x + 1
+
+-- Single clause (no alignment needed)
+baz x = x + 1
+
+-- Let binding with multiple clauses
+example f comp xs =
+  let h Nothing  Nothing  = EQ
       h (Just _) Nothing  = GT
-      h Nothing (Just _)  = LT
+      h Nothing  (Just _) = LT
       h (Just a) (Just b) = comp a b
   in  sortOnBy f h xs

--- a/test/snapshots/Integration.input
+++ b/test/snapshots/Integration.input
@@ -1,4 +1,4 @@
--- @format --align-equals --let-clause-same-line --single-line-let-in --where-clause-same-line --compact-records --arrow-last --import-sort-ide --unicode-always --then-new-line-for-long-line --width 80
+-- @format --align-clauses-full --let-clause-same-line --single-line-let-in --where-clause-same-line --compact-records --arrow-last --import-sort-ide --unicode-always --then-new-line-for-long-line --width 80
 module Integration where
 
 import Data.Maybe (Maybe(..))
@@ -12,12 +12,17 @@ classify config x = {value: x, category: result}
   where
     result = if x > config.threshold then "above" else "below"
 
--- Align equals across pattern match clauses
+-- Multi-clause with varying pattern widths (exercises both column and equals alignment)
 eval :: String -> Int -> Int
 eval "add" x = x + 1
 eval "double" x = x * 2
 eval "negate" x = negate x
 eval _ x = x
+
+-- Multi-clause with constructors of different widths
+fromMaybe' :: forall a. a -> Maybe a -> a
+fromMaybe' default Nothing = default
+fromMaybe' _ (Just x) = x
 
 -- Let with single binding (should stay on one line) and multi-binding
 transform :: Array Int -> Array Int
@@ -27,6 +32,16 @@ transform xs =
     doubled = map (\x -> x * 2) evens
     total = length doubled
   in  Tuple doubled total
+
+-- Multi-clause pattern match inside a let binding
+sortHelper :: forall a b. (a -> Maybe b) -> (b -> b -> Int) -> Array a -> Array a
+sortHelper f comp xs =
+  let
+    g Nothing Nothing = 0
+    g (Just _) Nothing = 1
+    g Nothing (Just _) = negate 1
+    g (Just a) (Just b) = comp a b
+  in xs
 
 -- Nested if-then-else (then placement matters with width constraint)
 describe :: Int -> String
@@ -39,7 +54,7 @@ compute a b = {sum: s, product: p}
     s = a + b
     p = a * b
 
--- Multi-clause in let binding with where
+-- Multi-clause in where block
 process :: forall a. (a -> Maybe a) -> Array a -> Tuple (Array a) Int
 process f xs = Tuple result count
   where

--- a/test/snapshots/Integration.output
+++ b/test/snapshots/Integration.output
@@ -11,12 +11,17 @@ classify config x = { value: x, category: result }
   where
   result = if x > config.threshold then "above" else "below"
 
--- Align equals across pattern match clauses
+-- Multi-clause with varying pattern widths (exercises both column and equals alignment)
 eval :: String -> Int -> Int
 eval "add" x = x + 1
 eval "double" x = x * 2
 eval "negate" x = negate x
 eval _ x = x
+
+-- Multi-clause with constructors of different widths
+fromMaybe' :: forall a. a -> Maybe a -> a
+fromMaybe' default Nothing = default
+fromMaybe' _ (Just x) = x
 
 -- Let with single binding (should stay on one line) and multi-binding
 transform :: Array Int -> Array Int
@@ -30,6 +35,17 @@ transform xs =
     in
       Tuple doubled total
 
+-- Multi-clause pattern match inside a let binding
+sortHelper :: forall a b. (a -> Maybe b) -> (b -> b -> Int) -> Array a -> Array a
+sortHelper f comp xs =
+  let
+    g Nothing Nothing = 0
+    g (Just _) Nothing = 1
+    g Nothing (Just _) = negate 1
+    g (Just a) (Just b) = comp a b
+  in
+    xs
+
 -- Nested if-then-else (then placement matters with width constraint)
 describe :: Int -> String
 describe n = if n > 100 then "large" else if n > 10 then "medium" else "small"
@@ -41,7 +57,7 @@ compute a b = { sum: s, product: p }
   s = a + b
   p = a * b
 
--- Multi-clause in let binding with where
+-- Multi-clause in where block
 process :: forall a. (a -> Maybe a) -> Array a -> Tuple (Array a) Int
 process f xs = Tuple result count
   where
@@ -61,7 +77,7 @@ class Showable a <= Displayable a where
 updateRecord :: { name :: String, age :: Int } -> { name :: String, age :: Int }
 updateRecord rec = rec { age = rec.age + 1 }
 
--- @format --align-equals --let-clause-same-line --single-line-let-in --where-clause-same-line --compact-records --arrow-last --import-sort-ide --unicode-always --then-new-line-for-long-line --width 80
+-- @format --align-clauses-full --let-clause-same-line --single-line-let-in --where-clause-same-line --compact-records --arrow-last --import-sort-ide --unicode-always --then-new-line-for-long-line --width 80
 module Integration where
 
 import Prelude
@@ -81,12 +97,17 @@ classify config x = {value: x, category: result}
   where
   result = if x > config.threshold then "above" else "below"
 
--- Align equals across pattern match clauses
+-- Multi-clause with varying pattern widths (exercises both column and equals alignment)
 eval ∷ String → Int → Int
-eval "add" x    = x + 1
+eval "add"    x = x + 1
 eval "double" x = x * 2
 eval "negate" x = negate x
-eval _ x        = x
+eval _        x = x
+
+-- Multi-clause with constructors of different widths
+fromMaybe' ∷ ∀ a. a → Maybe a → a
+fromMaybe' default Nothing  = default
+fromMaybe' _       (Just x) = x
 
 -- Let with single binding (should stay on one line) and multi-binding
 transform ∷ Array Int → Array Int
@@ -95,6 +116,15 @@ transform xs =
   in  let doubled = map (\x → x * 2) evens
           total = length doubled
   in  Tuple doubled total
+
+-- Multi-clause pattern match inside a let binding
+sortHelper ∷ ∀ a b. (a → Maybe b) → (b → b → Int) → Array a → Array a
+sortHelper f comp xs =
+  let g Nothing  Nothing  = 0
+      g (Just _) Nothing  = 1
+      g Nothing  (Just _) = negate 1
+      g (Just a) (Just b) = comp a b
+  in  xs
 
 -- Nested if-then-else (then placement matters with width constraint)
 describe ∷ Int → String
@@ -107,7 +137,7 @@ compute a b = {sum: s, product: p}
   s = a + b
   p = a * b
 
--- Multi-clause in let binding with where
+-- Multi-clause in where block
 process ∷ ∀ a. (a → Maybe a) → Array a → Tuple (Array a) Int
 process f xs = Tuple result count
   where


### PR DESCRIPTION
Excuse me for removing a flag that was just added. I just think this is a better design than adding yet another flag, and I wanted to get it right before people start using it. Also, thanks for merging the previous PRs so quickly!

The old `--align-equals` was a boolean that only padded before the `=` sign. The problem is that people who hand-format multi-clause functions usually also align the pattern columns, not just the `=`. Rather than adding a second flag for that, I replaced it with a single `--align-clauses` option that has three levels.

**`--align-clauses-none`** (default) — no alignment, same as before:

```purescript
g Nothing Nothing = EQ
g (Just _) Nothing = GT
g Nothing (Just _) = LT
g (Just a) (Just b) = comp a b
```

**`--align-clauses-equals`** — same behavior as the old `--align-equals`, only pads before `=`:

```purescript
g Nothing Nothing   = EQ
g (Just _) Nothing  = GT
g Nothing (Just _)  = LT
g (Just a) (Just b) = comp a b
```

**`--align-clauses-full`** — aligns each binder column and the `=` sign:

```purescript
g Nothing  Nothing  = EQ
g (Just _) Nothing  = GT
g Nothing  (Just _) = LT
g (Just a) (Just b) = comp a b
```

The full mode matches what you'd get if you hand-formatted the patterns into a table. It works for top-level declarations and let bindings, including with `--let-clause-same-line`. Functions with guarded bindings or a single clause are left alone.

I also updated the integration test to include more multi-clause functions that exercise the alignment.